### PR TITLE
use currentRoot for `.regression` images

### DIFF
--- a/lib/workflow.js
+++ b/lib/workflow.js
@@ -61,7 +61,7 @@ module.exports = function(pagename, args) {
         currentArgs:    currentArgs,
         queuedShots:    queuedShots,
         baselinePath:   this.screenshotRoot + '/' + pagename + '.' + currentArgs.name + '.baseline.png',
-        regressionPath: this.screenshotRoot + '/' + pagename + '.' + currentArgs.name + '.regression.png',
+        regressionPath: this.currentRoot + '/' + pagename + '.' + currentArgs.name + '.regression.png',
         diffPath:       this.failedComparisonsRoot + '/' + pagename + '.' + currentArgs.name + '.diff.png',
         screenshot:     this.currentRoot + '/' + pagename + '.png',
         isComparable:   false,


### PR DESCRIPTION
This is so that multiple processes can share the same baseline directory without writing images on top of each other.

`currentRoot` came from this commit:
https://github.com/webdriverio/webdrivercss/commit/9ee344943a3b510689070325099c644de5bc97a1